### PR TITLE
This enables ignore options to avoid adding media in some settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freik/audiodb",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "NodeJS Audio/Music database",
   "author": "Kevin Frei <kevinfrei@hotmail.com>",
   "license": "Unlicense",
@@ -38,16 +38,16 @@
     "@freik/core-utils": ">=1.2.0",
     "@freik/media-core": ">=0.11.0",
     "@freik/media-utils": ">=0.14.2",
-    "@freik/node-utils": ">=1.2.0",
+    "@freik/node-utils": ">=1.2.4",
     "xxhashjs": "^0.2.2"
   },
   "devDependencies": {
     "@freik/build-tools": "^3.4.5",
     "@types/jest": "^29.4.0",
-    "@types/rmfr": "^2.0.1",
+    "@types/rmfr": "^2.0.2",
     "@types/xxhashjs": "^0.2.2",
-    "@typescript-eslint/eslint-plugin": "^5.49.0",
-    "@typescript-eslint/parser": "^5.49.0",
+    "@typescript-eslint/eslint-plugin": "^5.50.0",
+    "@typescript-eslint/parser": "^5.50.0",
     "eslint": "^8.33.0",
     "eslint-config-prettier": "^8.6.0",
     "husky": "^8.0.3",
@@ -59,7 +59,7 @@
     "ts-jest": "^29.0.5",
     "typedoc": "^0.23.24",
     "typedoc-plugin-markdown": "^3.14.0",
-    "typescript": "^4.9.4"
+    "typescript": "^4.9.5"
   },
   "files": [
     "lib/**/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freik/audiodb",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "NodeJS Audio/Music database",
   "author": "Kevin Frei <kevinfrei@hotmail.com>",
   "license": "Unlicense",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freik/audiodb",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "NodeJS Audio/Music database",
   "author": "Kevin Frei <kevinfrei@hotmail.com>",
   "license": "Unlicense",

--- a/src/AudioDatabase.ts
+++ b/src/AudioDatabase.ts
@@ -28,6 +28,7 @@ import {
   PathUtil as path,
   PathUtil,
   Persist,
+  Watcher,
 } from '@freik/node-utils';
 import { promises as fsp } from 'fs';
 import { h32 } from 'xxhashjs';
@@ -189,6 +190,20 @@ function getPersistenceIdName(options?: Partial<AudioDatabaseOptions>): string {
     return 'audio-database';
   }
   return options.audioKey;
+}
+
+function makeFullOptions(
+  options?: Partial<AudioDatabaseOptions>,
+): AudioDatabaseOptions {
+  const fileWatchFilter: Watcher = (filepath: string) => {
+    return true;
+  };
+  return {
+    audioKey: 'audio-database',
+    watchHidden: false,
+    fileWatchFilter,
+    ...options,
+  };
 }
 
 /**

--- a/src/AudioDatabase.ts
+++ b/src/AudioDatabase.ts
@@ -849,13 +849,13 @@ export async function MakeAudioDatabase(
     ) {
       return false;
     }
-    // TODO: Extra validation?
+    // TODO: Extra validation!!!
     const songs = flattened.dbSongs as Map<SongKey, SongWithPath>;
     const albums = flattened.dbAlbums as Map<AlbumKey, Album>;
     const artists = flattened.dbArtists as Map<ArtistKey, Artist>;
     const titleIndex = flattened.albumTitleIndex as MultiMap<string, AlbumKey>;
     const nameIndex = flattened.artistNameIndex as Map<string, ArtistKey>;
-    const idx = flattened.indices as { location: string; hash: number }[];
+    const idx = flattened.indices as { location: string; hash: string }[];
     const audioIndices = new Map(
       (
         await Promise.all(

--- a/src/AudioDatabase.ts
+++ b/src/AudioDatabase.ts
@@ -181,6 +181,12 @@ function EnsureDiskNums(album: Album, diskNum?: number, diskName?: string) {
   }
 }
 
+/**
+ * This creates an Audio Database
+ * @param localStorageLocation The location to store stuff outside of any particular Audio File Index *or* the Persist object to store stuff in
+ * @param audioKey
+ * @returns An AudioDatabase
+ */
 export async function MakeAudioDatabase(
   localStorageLocation: string | Persist,
   audioKey?: string,

--- a/src/AudioDatabase.ts
+++ b/src/AudioDatabase.ts
@@ -193,11 +193,18 @@ function getPersistenceIdName(options?: Partial<AudioDatabaseOptions>): string {
 }
 
 function makeFullOptions(
+  extraIgnoreFunc: Watcher,
   options?: Partial<AudioDatabaseOptions>,
 ): AudioDatabaseOptions {
-  const fileWatchFilter: Watcher = (filepath: string) => {
-    return true;
-  };
+  const func: Watcher | undefined =
+    !Type.isUndefined(options) &&
+    Type.has(options, 'fileWatchFilter') &&
+    Type.isFunction(options.fileWatchFilter)
+      ? (options.fileWatchFilter as Watcher)
+      : undefined;
+  const fileWatchFilter: Watcher = Type.isUndefined(func)
+    ? extraIgnoreFunc
+    : (filepath: string) => extraIgnoreFunc(filepath) && func(filepath);
   return {
     audioKey: 'audio-database',
     watchHidden: false,

--- a/src/AudioDatabase.ts
+++ b/src/AudioDatabase.ts
@@ -936,12 +936,12 @@ export async function MakeAudioDatabase(
   }
 
   function addIgnoreItem(item: IgnoreType, value: string): void {
-    data.ignoreInfo.set(item, value);
+    data.ignoreInfo.set(item, value.toLocaleLowerCase());
     saveIgnoreInfo();
   }
 
   function removeIgnoreItem(item: IgnoreType, value: string): boolean {
-    if (data.ignoreInfo.remove(item, value)) {
+    if (data.ignoreInfo.remove(item, value.toLocaleLowerCase())) {
       saveIgnoreInfo();
       return true;
     }

--- a/src/AudioFileIndex.ts
+++ b/src/AudioFileIndex.ts
@@ -124,12 +124,12 @@ export function GetIndexForPath(pathName: string): AudioFileIndex | void {
 // Adds an index with the given hash value and location
 // It returns the encoded hash value for the location
 function addIndex(
-  hashValue: number,
+  hashValue: number | string,
   location: string,
   index: AudioFileIndex,
 ): string {
-  let b64 = ToB64(hashValue);
-  while (indexKeyLookup.has(b64)) {
+  let b64 = Type.isString(hashValue) ? hashValue : ToB64(hashValue);
+  while (Type.isNumber(hashValue) && indexKeyLookup.has(b64)) {
     const idx = indexKeyLookup.get(b64);
     if (idx === index || index.getLocation() === location) {
       if (idx !== index) {
@@ -200,7 +200,7 @@ export type AudioFileIndexOptions = {
 // store metadata & whatnot if the file system is read-only
 export async function MakeAudioFileIndex(
   locationName: string,
-  fragmentHash: number,
+  fragmentHash: number | string,
   options?: Partial<AudioFileIndexOptions>,
 ): Promise<AudioFileIndex> {
   /*
@@ -359,7 +359,7 @@ export async function MakeAudioFileIndex(
   // public
   function makeSongKey(songPath: string): SongKey {
     const relPath = getRelativePath(songPath);
-    let hash = h32(relPath, fragmentHash).toNumber();
+    let hash = h32(relPath, 0xbadf00d).toNumber();
     while (data.existingSongKeys.has(hash)) {
       const val = data.existingSongKeys.get(hash);
       if (Type.isString(val) && pathCompare(val, relPath) === 0) {

--- a/src/__tests__/AudioDatabase.test.ts
+++ b/src/__tests__/AudioDatabase.test.ts
@@ -293,9 +293,12 @@ it('Ignoring stuff', async () => {
   const db = await MakeAudioDatabase(persist);
   db.addIgnoreItem('dir-name', 'VA-AM Gold');
   expect(db).toBeDefined();
-  expect(
-    await db.addFileLocation('./src/__tests__/NotActuallyFiles'),
-  ).toBeTruthy();
+  if (!(await db.addFileLocation('./src/__tests__/NotActuallyFiles'))) {
+    await db.removeFileLocation('./src/__tests__/NotActuallyFiles');
+    expect(
+      await db.addFileLocation('./src/__tests__/NotActuallyFiles'),
+    ).toBeTruthy();
+  }
   expect(await db.refresh()).toBeTruthy();
   const flat = db.getFlatDatabase();
   expect(flat).toBeDefined();

--- a/src/__tests__/AudioDatabase.test.ts
+++ b/src/__tests__/AudioDatabase.test.ts
@@ -271,3 +271,33 @@ it('Rebuilding a DB after initial creation', async () => {
     'ZZ Top - 1992 - Greatest Hits/09 - Not qwerty another song [remix][w- Whitetown, Underworld & Yello].m4a',
   );
 });
+
+it('Loading and Saving', async () => {
+  const db = await MakeAudioDatabase(persist);
+  expect(db).toBeDefined();
+  expect(
+    await db.addFileLocation('./src/__tests__/NotActuallyFiles'),
+  ).toBeTruthy();
+  expect(await db.refresh()).toBeTruthy();
+  const flat = db.getFlatDatabase();
+  expect(flat).toBeDefined();
+  await db.save();
+
+  const db2 = await MakeAudioDatabase(persist);
+  expect(db2).toBeDefined();
+  expect(await db2.load()).toBeTruthy();
+});
+
+it('Ignoring stuff', async () => {
+  await Promise.resolve(process.nextTick);
+  const db = await MakeAudioDatabase(persist);
+  db.addIgnoreItem('dir-name', 'VA-AM Gold');
+  expect(db).toBeDefined();
+  expect(
+    await db.addFileLocation('./src/__tests__/NotActuallyFiles'),
+  ).toBeTruthy();
+  expect(await db.refresh()).toBeTruthy();
+  const flat = db.getFlatDatabase();
+  expect(flat).toBeDefined();
+  expect(flat.songs.length).toEqual(704);
+});

--- a/src/__tests__/AudioDatabase.test.ts
+++ b/src/__tests__/AudioDatabase.test.ts
@@ -291,7 +291,6 @@ it('Loading and Saving', async () => {
 it('Ignoring stuff', async () => {
   await Promise.resolve(process.nextTick);
   const db = await MakeAudioDatabase(persist);
-  db.addIgnoreItem('dir-name', 'VA-AM Gold');
   expect(db).toBeDefined();
   if (!(await db.addFileLocation('./src/__tests__/NotActuallyFiles'))) {
     await db.removeFileLocation('./src/__tests__/NotActuallyFiles');
@@ -299,8 +298,33 @@ it('Ignoring stuff', async () => {
       await db.addFileLocation('./src/__tests__/NotActuallyFiles'),
     ).toBeTruthy();
   }
+  let flat = db.getFlatDatabase();
+  expect(flat.songs.length).toEqual(743);
+  expect(flat.albums.length).toEqual(189);
+  expect(flat.artists.length).toEqual(273);
+
+  db.addIgnoreItem('dir-name', 'VA - AM Gold');
   expect(await db.refresh()).toBeTruthy();
-  const flat = db.getFlatDatabase();
+  flat = db.getFlatDatabase();
   expect(flat).toBeDefined();
-  expect(flat.songs.length).toEqual(704);
+  expect(flat.songs.length).toEqual(705);
+  expect(flat.albums.length).toEqual(188);
+  expect(flat.artists.length).toEqual(236);
+
+  expect(db.removeIgnoreItem('dir-name', 'VA - AM Gold')).toBeTruthy();
+  db.addIgnoreItem('path-keyword', 'Petty');
+  expect(await db.refresh()).toBeTruthy();
+  flat = db.getFlatDatabase();
+  expect(flat).toBeDefined();
+  expect(flat.songs.length).toEqual(730);
+  expect(flat.albums.length).toEqual(186);
+  expect(flat.artists.length).toEqual(272);
+
+  db.addIgnoreItem('path-root', '/Utah Saints - 1992 - Utah Saints');
+  expect(await db.refresh()).toBeTruthy();
+  flat = db.getFlatDatabase();
+  expect(flat).toBeDefined();
+  expect(flat.songs.length).toEqual(726);
+  expect(flat.albums.length).toEqual(185);
+  expect(flat.artists.length).toEqual(271);
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2204,10 +2204,10 @@ __metadata:
     "@freik/media-utils": ">=0.14.2"
     "@freik/node-utils": ">=1.2.0"
     "@types/jest": ^29.4.0
-    "@types/rmfr": ^2.0.1
+    "@types/rmfr": ^2.0.2
     "@types/xxhashjs": ^0.2.2
-    "@typescript-eslint/eslint-plugin": ^5.49.0
-    "@typescript-eslint/parser": ^5.49.0
+    "@typescript-eslint/eslint-plugin": ^5.50.0
+    "@typescript-eslint/parser": ^5.50.0
     eslint: ^8.33.0
     eslint-config-prettier: ^8.6.0
     husky: ^8.0.3
@@ -2219,7 +2219,7 @@ __metadata:
     ts-jest: ^29.0.5
     typedoc: ^0.23.24
     typedoc-plugin-markdown: ^3.14.0
-    typescript: ^4.9.4
+    typescript: ^4.9.5
     xxhashjs: ^0.2.2
   languageName: unknown
   linkType: soft
@@ -3325,22 +3325,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/rimraf@npm:*":
-  version: 3.0.2
-  resolution: "@types/rimraf@npm:3.0.2"
+"@types/rimraf@npm:^2.0.3":
+  version: 2.0.5
+  resolution: "@types/rimraf@npm:2.0.5"
   dependencies:
     "@types/glob": "*"
     "@types/node": "*"
-  checksum: b47fa302f46434cba704d20465861ad250df79467d3d289f9d6490d3aeeb41e8cb32dd80bd1a8fd833d1e185ac719fbf9be12e05ad9ce9be094d8ee8f1405347
+  checksum: e388f546840704a240fb31536498921623bca4ec1230925013d6b6d7c7d2211c8ec07fcbbd2606151d7549cbbc28a01c18fb0df502107a9293860a5ff64bc147
   languageName: node
   linkType: hard
 
-"@types/rmfr@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@types/rmfr@npm:2.0.1"
+"@types/rmfr@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "@types/rmfr@npm:2.0.2"
   dependencies:
-    "@types/rimraf": "*"
-  checksum: de8ad706de6c0ecfb711382f17a13adb8a5df5043182f82cd3d8668c9d36e4cdb5568d1275122777be1cd8a791016e8c1dae34f41f9087808b03d7a36e003c24
+    "@types/rimraf": ^2.0.3
+  checksum: a7a22bd8ecef0efe6446edd9c92fd2b9fe0d462975fc65b96586f773e030b75df35accde153794f8109e2a58b79a980723cf5567c6a177fee24ce4eeb2472dab
   languageName: node
   linkType: hard
 
@@ -3383,14 +3383,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:^5.49.0":
-  version: 5.49.0
-  resolution: "@typescript-eslint/eslint-plugin@npm:5.49.0"
+"@typescript-eslint/eslint-plugin@npm:^5.50.0":
+  version: 5.50.0
+  resolution: "@typescript-eslint/eslint-plugin@npm:5.50.0"
   dependencies:
-    "@typescript-eslint/scope-manager": 5.49.0
-    "@typescript-eslint/type-utils": 5.49.0
-    "@typescript-eslint/utils": 5.49.0
+    "@typescript-eslint/scope-manager": 5.50.0
+    "@typescript-eslint/type-utils": 5.50.0
+    "@typescript-eslint/utils": 5.50.0
     debug: ^4.3.4
+    grapheme-splitter: ^1.0.4
     ignore: ^5.2.0
     natural-compare-lite: ^1.4.0
     regexpp: ^3.2.0
@@ -3402,24 +3403,24 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 15423cd9fde1ac3f8ba34526a07e537464e70463f1af784be5567fdc78e5745352fa0a2c3be0c13d066bc4b9720b5fa438d64647f624d29722eb4f158c039dcc
+  checksum: 351c4a157a7d717cc3835bdc09324b20d649463738a029c5701e5a38cdb162305ff7d56adff196a0c3245c24ea3167bbdac7f1c30399b8c1d495abbdbc1c53d6
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:^5.49.0":
-  version: 5.49.0
-  resolution: "@typescript-eslint/parser@npm:5.49.0"
+"@typescript-eslint/parser@npm:^5.50.0":
+  version: 5.50.0
+  resolution: "@typescript-eslint/parser@npm:5.50.0"
   dependencies:
-    "@typescript-eslint/scope-manager": 5.49.0
-    "@typescript-eslint/types": 5.49.0
-    "@typescript-eslint/typescript-estree": 5.49.0
+    "@typescript-eslint/scope-manager": 5.50.0
+    "@typescript-eslint/types": 5.50.0
+    "@typescript-eslint/typescript-estree": 5.50.0
     debug: ^4.3.4
   peerDependencies:
     eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 87b3760cfc29b3edd3d28fe0d5e9e5a3833d60398d7779ecc657b9e3bfec624cd464176e26b24b0761fb79cc88daddae19560340f91119c4856b91f9663594dd
+  checksum: 816a421ce9a5c61a2e92499d6d400aed4211ca5b685e0212844b6659f7acfeba1cca0418b462236c44eea6e8a2574cd51ccb7abc2bf4a8cad5b7a275d71ae9bf
   languageName: node
   linkType: hard
 
@@ -3450,22 +3451,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:5.49.0":
-  version: 5.49.0
-  resolution: "@typescript-eslint/scope-manager@npm:5.49.0"
+"@typescript-eslint/scope-manager@npm:5.50.0":
+  version: 5.50.0
+  resolution: "@typescript-eslint/scope-manager@npm:5.50.0"
   dependencies:
-    "@typescript-eslint/types": 5.49.0
-    "@typescript-eslint/visitor-keys": 5.49.0
-  checksum: 466047e24ff8a4195f14aadde39375f22891bdaced09e58c89f2c32af0aa4a0d87e71a5f006f6ab76858e6f30c4b764b1e0ef7bc26713bb78add30638108c45f
+    "@typescript-eslint/types": 5.50.0
+    "@typescript-eslint/visitor-keys": 5.50.0
+  checksum: bd49447a834c82cb130e6900644042c3a84195bf7a63483385e90b6454c65856d6f276c997cad6bf9c36c9d0cb168fdde625ce4c78c3b8bcce42da782270794b
   languageName: node
   linkType: hard
 
-"@typescript-eslint/type-utils@npm:5.49.0":
-  version: 5.49.0
-  resolution: "@typescript-eslint/type-utils@npm:5.49.0"
+"@typescript-eslint/type-utils@npm:5.50.0":
+  version: 5.50.0
+  resolution: "@typescript-eslint/type-utils@npm:5.50.0"
   dependencies:
-    "@typescript-eslint/typescript-estree": 5.49.0
-    "@typescript-eslint/utils": 5.49.0
+    "@typescript-eslint/typescript-estree": 5.50.0
+    "@typescript-eslint/utils": 5.50.0
     debug: ^4.3.4
     tsutils: ^3.21.0
   peerDependencies:
@@ -3473,7 +3474,7 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 9dcee0a21cfdb3549e2305120535af5ab2c5d0cafdd410827e79d7548f8fc4e7da7cbb77a4338ade8b8b8aaf246fee56b919f1857931bbe2ac5df2fbb5e62ee6
+  checksum: d2fc2fd10ef300865fd6a902ae92aef6c45cddc4359445f1e5c6dc9511063b52d2170cc6b525763395d4171c177b3d0fffd77cf9a2ab7e01fcd7109bd1a5a585
   languageName: node
   linkType: hard
 
@@ -3484,10 +3485,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:5.49.0":
-  version: 5.49.0
-  resolution: "@typescript-eslint/types@npm:5.49.0"
-  checksum: 41f72a043007fc3f3356b5a38d7bfa54871545b4a309810a062f044cff25122413a9660ce6d83d1221762f60d067351d020b0cb68f7e1279817f53e77ce8f33d
+"@typescript-eslint/types@npm:5.50.0":
+  version: 5.50.0
+  resolution: "@typescript-eslint/types@npm:5.50.0"
+  checksum: 1189c63d35abeec685dd519fd923926b884e63d5e10e4a9fe995aebfde59b8a2e10773090ec3ba32a0ec408746b18f6a454d9bedb0b6c7ce8b6066547144fb4d
   languageName: node
   linkType: hard
 
@@ -3509,12 +3510,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:5.49.0":
-  version: 5.49.0
-  resolution: "@typescript-eslint/typescript-estree@npm:5.49.0"
+"@typescript-eslint/typescript-estree@npm:5.50.0":
+  version: 5.50.0
+  resolution: "@typescript-eslint/typescript-estree@npm:5.50.0"
   dependencies:
-    "@typescript-eslint/types": 5.49.0
-    "@typescript-eslint/visitor-keys": 5.49.0
+    "@typescript-eslint/types": 5.50.0
+    "@typescript-eslint/visitor-keys": 5.50.0
     debug: ^4.3.4
     globby: ^11.1.0
     is-glob: ^4.0.3
@@ -3523,25 +3524,25 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: f331af9f0ef3ce3157c421b8cc727dec5aa0a60add305aa4c676a02c63ec07799105268af192c5ed193a682b7ed804564d29d49bdbd2019678e495d80e65e29a
+  checksum: cb1ac8d39647da6d52750c713d9635750ed41245ec82f937a159a71ad3bf490ebabfad3b43eeca07bca39d60df30d3a2f31f8bed0061381731d92a62e284b867
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:5.49.0":
-  version: 5.49.0
-  resolution: "@typescript-eslint/utils@npm:5.49.0"
+"@typescript-eslint/utils@npm:5.50.0":
+  version: 5.50.0
+  resolution: "@typescript-eslint/utils@npm:5.50.0"
   dependencies:
     "@types/json-schema": ^7.0.9
     "@types/semver": ^7.3.12
-    "@typescript-eslint/scope-manager": 5.49.0
-    "@typescript-eslint/types": 5.49.0
-    "@typescript-eslint/typescript-estree": 5.49.0
+    "@typescript-eslint/scope-manager": 5.50.0
+    "@typescript-eslint/types": 5.50.0
+    "@typescript-eslint/typescript-estree": 5.50.0
     eslint-scope: ^5.1.1
     eslint-utils: ^3.0.0
     semver: ^7.3.7
   peerDependencies:
     eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-  checksum: 8218c566637d5104dfb2346216f8cb4c244f31c2a39e261aafe554b8abd48bd630a0d0807a0a8d776af8f9d9914c8776d86abf0a523049f3c5619c498a7e5b1e
+  checksum: 4471ae8b24449300e009f1cc09ee0d38cce20ae9171e8fbf4ef752ce4eb87104cc0d813d8f7051b619fa05e1e7c12b748dad49832911685297b1bbfef3c01f0b
   languageName: node
   linkType: hard
 
@@ -3555,13 +3556,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/visitor-keys@npm:5.49.0":
-  version: 5.49.0
-  resolution: "@typescript-eslint/visitor-keys@npm:5.49.0"
+"@typescript-eslint/visitor-keys@npm:5.50.0":
+  version: 5.50.0
+  resolution: "@typescript-eslint/visitor-keys@npm:5.50.0"
   dependencies:
-    "@typescript-eslint/types": 5.49.0
+    "@typescript-eslint/types": 5.50.0
     eslint-visitor-keys: ^3.3.0
-  checksum: 46dc7bc713e8825d1fccba521fdf7c6e2f8829e491c2afd44dbe4105c6432e3c3dfe7e1ecb221401269d639264bb4af77b60a7b65521fcff9ab02cd31d8ef782
+  checksum: 55319cb7ee7b78d07d9dc67a388d69fe0b7f11cbc79190e17e7f87a39c9992d08dab3b5872d5a7f01094dda28ad6ac61d3573e59015ef70bf138d4c4f8c45b88
   languageName: node
   linkType: hard
 
@@ -10081,7 +10082,17 @@ resolve@^1.22.1:
   languageName: node
   linkType: hard
 
-"typescript@^4.9.4, typescript@npm:~4.9.4":
+"typescript@npm:^4.9.5":
+  version: 4.9.5
+  resolution: "typescript@npm:4.9.5"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: ee000bc26848147ad423b581bd250075662a354d84f0e06eb76d3b892328d8d4440b7487b5a83e851b12b255f55d71835b008a66cbf8f255a11e4400159237db
+  languageName: node
+  linkType: hard
+
+"typescript@npm:~4.9.4":
   version: 4.9.4
   resolution: "typescript@npm:4.9.4"
   bin:
@@ -10091,7 +10102,17 @@ resolve@^1.22.1:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^4.9.4#~builtin<compat/typescript>, typescript@patch:typescript@~4.9.4#~builtin<compat/typescript>":
+"typescript@patch:typescript@^4.9.5#~builtin<compat/typescript>":
+  version: 4.9.5
+  resolution: "typescript@patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>::version=4.9.5&hash=ad5954"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 8f6260acc86b56bfdda6004bc53f32ea548f543e8baef7071c8e34d29d292f3e375c8416556c8de10b24deef6933cd1c16a8233dc84a3dd43a13a13265d0faab
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@~4.9.4#~builtin<compat/typescript>":
   version: 4.9.4
   resolution: "typescript@patch:typescript@npm%3A4.9.4#~builtin<compat/typescript>::version=4.9.4&hash=ad5954"
   bin:


### PR DESCRIPTION
3 types: You can have a 'path-keyword' which just checks for substring, 'path-root' which will match a fully-rooted path, and 'dir-name' which will match a full directory (anywhere in the file-index-relative path)